### PR TITLE
Switches to object config argument syntax over mutli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Any time the user data changes, the UserAuthWrapper will re-check for authentica
 
 * `authSelector(state, [ownProps]): authData` \(*Function*): A state selector for the auth data. Just like `mapToStateProps`
 * `[failureRedirectPath]` \(*String*): Optional path to redirect the browser to on a failed check. Defaults to `/login`
-* `[wrapperDisplayName]` \(*String*): Option name describing this authentication or authorization check.
+* `[wrapperDisplayName]` \(*String*): Optional name describing this authentication or authorization check.
 It will display in React-devtools. Defaults to `UserAuthWrapper`
 * `[predicate(authData): Bool]` \(*Function*): Optional function to be passed the result of the `userAuthSelector` param.
 If it evaluates to false the browser will be redirected to `failureRedirectPath`, otherwise `DecoratedComponent` will be rendered.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Any time the user data changes, the UserAuthWrapper will re-check for authentica
 
 * `authSelector(state, [ownProps]): authData` \(*Function*): A state selector for the auth data. Just like `mapToStateProps`
 * `[failureRedirectPath]` \(*String*): Optional path to redirect the browser to on a failed check. Defaults to `/login`
-* `[wrapperDisplayName]` \(*String*): Option name describing this authentication or authorization check. It will display in React-devtools
+* `[wrapperDisplayName]` \(*String*): Option name describing this authentication or authorization check.
+It will display in React-devtools. Defaults to `UserAuthWrapper`
 * `[predicate(authData): Bool]` \(*Function*): Optional function to be passed the result of the `userAuthSelector` param.
 If it evaluates to false the browser will be redirected to `failureRedirectPath`, otherwise `DecoratedComponent` will be rendered.
 * `[allowRedirect]` \(*Bool*): Optional bool on whether to pass a `redirect` query parameter to the `failureRedirectPath`

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -33,8 +33,17 @@ const finalCreateStore = compose(
 const store = finalCreateStore(reducer)
 routingMiddleware.listenForReplays(store)
 
-const UserIsAuthenticated = UserAuthWrapper(state => state.user)('/login', 'UserIsAuthenticated')
-const UserIsAdmin = UserAuthWrapper(state => state.user)('/', 'UserIsAdmin', user => user.isAdmin, false)
+const UserIsAuthenticated = UserAuthWrapper({
+  authSelector: state => state.user,
+  wrapperDisplayName: 'UserIsAuthenticated'
+})
+const UserIsAdmin = UserAuthWrapper({
+  authSelector: state => state.user,
+  failureRedirectPath: '/app',
+  wrapperDisplayName: 'UserIsAdmin',
+  predicate: user => user.isAdmin,
+  allowRedirectBack: false
+})
 
 ReactDOM.render(
   <Provider store={store}>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "redux-simple-router": "~2.0.3"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.3"
+    "hoist-non-react-statics": "^1.0.3",
+    "lodash.isempty": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "redux-simple-router": "~2.0.3"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.3",
-    "lodash.isempty": "^4.1.0"
+    "hoist-non-react-statics": "1.0.5",
+    "lodash.isempty": "4.1.0",
+    "warning": "2.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,21 +2,7 @@ import React, { Component, PropTypes } from 'react'
 import { routeActions } from 'redux-simple-router'
 import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
-
-const emptyOrNull = obj => {
-  // null and undefined are "empty"
-  if (obj == null) return true
-
-  // Assume if it has a length property with a non-zero value
-  // that that property is correct.
-  if (obj.length > 0)    return false
-  if (obj.length === 0)  return true
-
-  // Otherwise, does it have any properties of its own?
-  if (Object.getOwnPropertyNames(obj).length > 0) return false
-
-  return true
-}
+import isEmpty from 'lodash.isempty'
 
 /**
 * A function which simplifies User Authentication and Authorization
@@ -34,7 +20,7 @@ const emptyOrNull = obj => {
 */
 
 export const UserAuthWrapper = authSelector =>
-  (failureRedirectPath, wrapperDisplayName, predicate = x => !emptyOrNull(x), allowRedirectBack = true) => {
+  (failureRedirectPath, wrapperDisplayName, predicate = x => !isEmpty(x), allowRedirectBack = true) => {
     // Wraps the component that needs the auth enforcement
     return function wrapComponent(DecoratedComponent) {
       const displayName = DecoratedComponent.displayName || DecoratedComponent.name || 'Component'

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const UserAuthWrapper = (args) => {
 // Support the old 0.1.x with deprecation warning
 const DeprecatedWrapper = authSelector =>
   (failureRedirectPath, wrapperDisplayName, predicate = x => !isEmpty(x), allowRedirectBack = true) => {
-    warning(false, 'Using arg style syntax for UserAuthWrapper has been deprecated, please pass a config object instead. See the docs for the new usage')
+    warning(false, `Deprecated arg style syntax found for auth wrapped named ${wrapperDisplayName}. Pass a config object instead`)
     return UserAuthWrapper({
       ...defaults,
       authSelector,

--- a/src/index.js
+++ b/src/index.js
@@ -3,86 +3,106 @@ import { routeActions } from 'redux-simple-router'
 import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
 import isEmpty from 'lodash.isempty'
+import warning from 'warning'
 
-/**
-* A function which simplifies User Authentication and Authorization
-* It is first passed a state selector for the authorization data and then can be passed the properties for
-* authentication and authorization checking. Finally it will wrap any component that it is passed
-*
-* @param authSelector - State select for the auth data
-* @param failureRedirectPath - Path to redirect the user to should the the predicate be is false
-* @param wrapperDisplayName - Display name to be shown in the React Developer Console of the wrapped component
-* @param predicate - From UserData to Boolean, if true the wrapped component is displayed, otherwise redirected
-* Defaults to true if the user is logged in
-* @param allowRedirectBack - If true the current path is saved in the new router state, allowing for a redirect back
-* @returns A function which when applied to a component returns a new component with User Authentication and
-* Authorization enforced
-*/
+const defaults = {
+  failureRedirectPath: '/login',
+  wrapperDisplayName: 'AuthWrapper',
+  predicate: x => !isEmpty(x),
+  allowRedirectBack: true
+}
 
-export const UserAuthWrapper = authSelector =>
-  (failureRedirectPath, wrapperDisplayName, predicate = x => !isEmpty(x), allowRedirectBack = true) => {
-    // Wraps the component that needs the auth enforcement
-    return function wrapComponent(DecoratedComponent) {
-      const displayName = DecoratedComponent.displayName || DecoratedComponent.name || 'Component'
+const UserAuthWrapper = (args) => {
+  const { authSelector, failureRedirectPath, wrapperDisplayName, predicate, allowRedirectBack } = {
+    ...defaults,
+    ...args
+  }
+  // Wraps the component that needs the auth enforcement
+  return function wrapComponent(DecoratedComponent) {
+    const displayName = DecoratedComponent.displayName || DecoratedComponent.name || 'Component'
 
-      @connect(
-        state => { return { authData: authSelector(state) } },
-        { replace: routeActions.replace }
-      )
-      class UserAuthWrapper extends Component {
+    @connect(
+      state => { return { authData: authSelector(state) } },
+      { replace: routeActions.replace }
+    )
+    class UserAuthWrapper extends Component {
 
-        static displayName = `${wrapperDisplayName}(${displayName})`;
+      static displayName = `${wrapperDisplayName}(${displayName})`;
 
-        static propTypes = {
-          location: PropTypes.shape({
-            pathname: PropTypes.string.isRequired,
-            search: PropTypes.string.isRequired
-          }).isRequired,
-          replace: PropTypes.func.isRequired,
-          authData: PropTypes.object
-        };
+      static propTypes = {
+        location: PropTypes.shape({
+          pathname: PropTypes.string.isRequired,
+          search: PropTypes.string.isRequired
+        }).isRequired,
+        replace: PropTypes.func.isRequired,
+        authData: PropTypes.object
+      };
 
-        componentWillMount() {
-          this.ensureLoggedIn(this.props)
-        }
-
-        componentWillReceiveProps(nextProps) {
-          this.ensureLoggedIn(nextProps)
-        }
-
-        isAuthorized = (authData) => predicate(authData);
-
-        ensureLoggedIn = (props) => {
-          const { replace, location, authData } = props
-          let query
-          if (allowRedirectBack) {
-            query = { redirect: `${location.pathname}${location.search}` }
-          } else {
-            query = {}
-          }
-
-          if (!this.isAuthorized(authData)) {
-            replace({
-              pathname: failureRedirectPath,
-              query
-            })
-          }
-        };
-
-        render() {
-          // Allow everything but the replace aciton creator to be passed down
-          // Includes route props from React-Router and authData
-          const { replace, authData, ...otherProps } = this.props
-
-          if (this.isAuthorized(authData)) {
-            return <DecoratedComponent authData={authData} {...otherProps} />
-          } else {
-            // Don't need to display anything because the user will be redirected
-            return <div/>
-          }
-        }
+      componentWillMount() {
+        this.ensureLoggedIn(this.props)
       }
 
-      return hoistStatics(UserAuthWrapper, DecoratedComponent)
+      componentWillReceiveProps(nextProps) {
+        this.ensureLoggedIn(nextProps)
+      }
+
+      isAuthorized = (authData) => predicate(authData);
+
+      ensureLoggedIn = (props) => {
+        const { replace, location, authData } = props
+        let query
+        if (allowRedirectBack) {
+          query = { redirect: `${location.pathname}${location.search}` }
+        } else {
+          query = {}
+        }
+
+        if (!this.isAuthorized(authData)) {
+          replace({
+            pathname: failureRedirectPath,
+            query
+          })
+        }
+      };
+
+      render() {
+        // Allow everything but the replace aciton creator to be passed down
+        // Includes route props from React-Router and authData
+        const { replace, authData, ...otherProps } = this.props
+
+        if (this.isAuthorized(authData)) {
+          return <DecoratedComponent authData={authData} {...otherProps} />
+        } else {
+          // Don't need to display anything because the user will be redirected
+          return <div/>
+        }
+      }
     }
+
+    return hoistStatics(UserAuthWrapper, DecoratedComponent)
   }
+}
+
+// Support the old 0.1.x with deprecation warning
+const DeprecatedWrapper = authSelector =>
+  (failureRedirectPath, wrapperDisplayName, predicate = x => !isEmpty(x), allowRedirectBack = true) => {
+    warning(false, 'Using arg style syntax for UserAuthWrapper has been deprecated, please pass a config object instead. See the docs for the new usage')
+    return UserAuthWrapper({
+      ...defaults,
+      authSelector,
+      failureRedirectPath,
+      wrapperDisplayName,
+      predicate,
+      allowRedirectBack
+    })
+  }
+
+const BackwardsCompatWrapper = (arg) => {
+  if (typeof arg === 'function') {
+    return DeprecatedWrapper(arg)
+  } else {
+    return UserAuthWrapper(arg)
+  }
+}
+
+module.exports.UserAuthWrapper = BackwardsCompatWrapper

--- a/test/UserAuthWrapper-test.js
+++ b/test/UserAuthWrapper-test.js
@@ -39,12 +39,27 @@ const configureStore = (history, initialState) => {
 
 const userSelector = state => state.user
 
-const UserIsAuthenticated = UserAuthWrapper(userSelector)('/login', 'UserIsAuthenticated')
+const UserIsAuthenticated = UserAuthWrapper({
+  authSelector: userSelector,
+  wrapperDisplayName: 'UserIsAuthenticated'
+})
 
-const HiddenNoRedir = UserAuthWrapper(userSelector)('/', 'NoRedir', () => false, false)
+const HiddenNoRedir = UserAuthWrapper({
+  authSelector: userSelector,
+  failureRedirectPath: '/',
+  wrapperDisplayName: 'NoRedir',
+  predicate: () => false,
+  allowRedirectBack: false
+})
 
-const UserIsOnlyTest = UserAuthWrapper(userSelector)('/', 'UserIsOnlyTest', user => user.firstName === 'Test')
+const UserIsOnlyTest = UserAuthWrapper({
+  authSelector: userSelector,
+  failureRedirectPath: '/',
+  wrapperDisplayName: 'UserIsOnlyTest',
+  predicate: user => user.firstName === 'Test'
+})
 
+// Intential deprecated version
 const UserIsOnlyMcDuderson = UserAuthWrapper(userSelector)('/', 'UserIsOnlyMcDuderson', user => user.lastName === 'McDuderson')
 
 class App extends Component {


### PR DESCRIPTION
Resolves #8

Allows for far more variety of config options and lets the user set the fields they really want. Previously if the user wanted `allowRedirectBack` to be false, they had to specify `predicate` even if they wanted the default behavior.

```js
const UserIsAuthenticated = UserAuthWrapper(state => state.user)('/login', 'UserIsAuthenticated')
```

becomes
```js
const UserIsAuthenticated = UserAuthWrapper({
  authSelector: state => state.user,
  wrapperDisplayName: 'UserIsAuthenticated'
})
```

Preserves a backwards (deprecated) compatible version.

Updated tests, README, and examples.
