### PR TITLE
Prevent Possible Infinite Redirects in ComponentWillReceiveProps

### DIFF
--- a/examples/basic/components/Login.js
+++ b/examples/basic/components/Login.js
@@ -21,20 +21,20 @@ class LoginContainer extends Component {
     };
 
     componentWillMount() {
-      this.ensureNotLoggedIn(this.props)
-    }
-
-    componentWillReceiveProps(nextProps) {
-      this.ensureNotLoggedIn(nextProps)
-    }
-
-    ensureNotLoggedIn = (props) => {
-      const { isAuthenticated, replace, redirect } = props
-
+      const { isAuthenticated, replace, redirect } = this.props
       if (isAuthenticated) {
         replace(redirect)
       }
-    };
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const { isAuthenticated, replace, redirect } = nextProps
+      const { isAuthenticated: wasAuthenticated } = this.props
+
+      if (!wasAuthenticated && isAuthenticated) {
+        replace(redirect)
+      }
+    }
 
     onClick = (e) => {
       e.preventDefault()

--- a/examples/localStorage/components/Login.js
+++ b/examples/localStorage/components/Login.js
@@ -21,20 +21,20 @@ class LoginContainer extends Component {
     };
 
     componentWillMount() {
-      this.ensureNotLoggedIn(this.props)
-    }
-
-    componentWillReceiveProps(nextProps) {
-      this.ensureNotLoggedIn(nextProps)
-    }
-
-    ensureNotLoggedIn = (props) => {
-      const { isAuthenticated, replace, redirect } = props
-
+      const { isAuthenticated, replace, redirect } = this.props
       if (isAuthenticated) {
         replace(redirect)
       }
-    };
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const { isAuthenticated, replace, redirect } = nextProps
+      const { isAuthenticated: wasAuthenticated } = this.props
+
+      if (!wasAuthenticated && isAuthenticated) {
+        replace(redirect)
+      }
+    }
 
     onClick = (e) => {
       e.preventDefault()


### PR DESCRIPTION
Based on feedback from https://github.com/facebook/react/issues/7025, the checks on whether to redirect made in the componentWillReceive props did not account for cWRP being invoked multiple times when isAuthenticated returned false. It incorrectly assumed the user would be redirected before another cWRP call. 

Fixed this and updated the Login component examples as well.

Probably related to #44, will confirm with further testing