### PR TITLE
Fix example in "Protecting Multiple Routes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ export default UserIsAuthenticated(MyComponent)
 Because routes in React Router are not required to have paths, you can use nesting to protect multiple routes without applying
 the wrapper multiple times.
 ```js
-const Authenticated = UserIsAuthenticated((props) => props.children);
+const Authenticated = UserIsAuthenticated((props) => React.cloneElement(props.children, props));
 
 <Route path='/' component={App}>
    <IndexRedirect to="/login" />


### PR DESCRIPTION
In the example, the current `Authentication` HOC defined as follows:
```javascript
const Authenticated = UserIsAuthenticated((props) => props.children)
```
This causes children components to lose properties that were passed to them by the parent component.

This is fixed by using `cloneElement`:
```javascript
const Authenticated = UserIsAuthenticated((props) => React.cloneElement(props.children, props))
```