### PR TITLE
Partial compatibility with React Router v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-rackt": "1.1.1",
     "eslint-plugin-react": "3.16.0",
     "expect": "1.20.2",
+    "history": "4.6.0",
     "jsdom": "9.8.3",
     "lodash": "4.16.6",
     "mocha": "3.1.2",
@@ -50,7 +51,7 @@
     "react-addons-test-utils": "15.3.2",
     "react-dom": "15.3.2",
     "react-redux": "4.4.5",
-    "react-router": "3.0.0",
+    "react-router": "4.0.0-beta.7",
     "react-router-redux": "4.0.7",
     "redux": "3.6.0",
     "sinon": "1.17.6",
@@ -58,6 +59,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "1.2.0",
-    "lodash.isempty": "4.4.0"
+    "lodash.isempty": "4.4.0",
+    "query-string": "^4.3.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
 import isEmpty from 'lodash.isempty'
 import url from 'url'
+import { stringify } from 'query-string'
 
 const defaults = {
   LoadingComponent: () => null, // dont render anything while authenticating
@@ -44,6 +45,7 @@ export const UserAuthWrapper = (args) => {
 
     redirect({
       pathname: redirectLoc.pathname,
+      search: stringify(query),
       query
     })
   }
@@ -89,7 +91,7 @@ export const UserAuthWrapper = (args) => {
 
       static contextTypes = {
         // Only used if no redirectAction specified
-        router: PropTypes.object
+        history: PropTypes.object
       };
 
       componentWillMount() {
@@ -123,11 +125,12 @@ export const UserAuthWrapper = (args) => {
         if (redirect) {
           return redirect
         } else {
-          if (!this.context.router.replace) {
+          const { replace } = this.context.history
+          if (!replace) {
             /* istanbul ignore next sanity */
-            throw new Error(`You must provide a router context (or use React-Router 2.x) if not passing a redirectAction to ${wrapperDisplayName}`)
+            throw new Error(`You must provide a history (React Router v4.x) if not passing a redirectAction to ${wrapperDisplayName}`)
           } else {
-            return this.context.router.replace
+            return replace
           }
         }
       };


### PR DESCRIPTION
I made a start at implementing changes needed for compatibility with `react-router` v4. This is not complete and I don't expect you to merge it. Feel free to close this PR and pick out any parts that might be useful when you update `redux-auth-wrapper` to RR v4 compatibility.

The main changes are in the tests:

- Added `history` to the tests, as it's now an external dependency of RR v4
- `react-router-redux` is not fully compatible with RR v4 yet, so I'm just accessing paths directly from the `history`. The history is not synced to the state, but new locations can still be triggered by redux actions.
- I had to slightly restructure all the route configs, not sure if that's a problem with my understanding of how they should work, or some other issue

There are two tests that fail:
```
  2 failing

  1) UserAuthWrapper passes props to authed components:

      AssertionError: expected [ Array(5) ] to deeply equal [ Array(7) ]
      + expected - actual

       [
         "authData"
      +  "children"
         "history"
         "location"
         "match"
      +  "params"
         "testProp"
       ]

      at Assertion.assertEqual (node_modules/chai/lib/chai/core/assertions.js:485:19)
      at Assertion.ctx.(anonymous function) [as equal] (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at Context.<anonymous> (test/UserAuthWrapper-test.js:435:84)

  2) UserAuthWrapper provides an onEnter static function:
     AssertionError: expected false to be true
      at Context.<anonymous> (test/UserAuthWrapper-test.js:492:5)
```

Hopefully some of this is useful!

Refs #127