### PR TITLE
Accept any type as return of authSelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "1.2.0",
+    "lodash.isboolean": "^3.0.3",
     "lodash.isempty": "4.4.0",
     "prop-types": "15.5.8"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import hoistStatics from 'hoist-non-react-statics'
+import isBoolean from 'lodash.isboolean'
 import isEmpty from 'lodash.isempty'
 import url from 'url'
 
@@ -11,7 +12,7 @@ const defaults = {
   FailureComponent: undefined,
   redirectQueryParamName: 'redirect',
   wrapperDisplayName: 'AuthWrapper',
-  predicate: x => !isEmpty(x),
+  predicate: x => isBoolean(x) ? x : !isEmpty(x),
   authenticatingSelector: () => false,
   allowRedirectBack: true,
   propMapper: ({ redirect, authData, isAuthenticating, failureRedirectPath, ...otherProps }) => ({ authData, ...otherProps }) // eslint-disable-line no-unused-vars

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ export const UserAuthWrapper = (args) => {
         failureRedirectPath: PropTypes.string.isRequired,
         location: shouldRedirect ? locationShape.isRequired : locationShape,
         redirect: PropTypes.func,
-        authData: PropTypes.object
+        authData: PropTypes.any
       };
 
       static contextTypes = {


### PR DESCRIPTION
I see no reason to expect an object as return of `authSelector` and it would help people like me that already have a `isAuthenticated` selector that returns a boolean.

In my case it gets really weird since I don't have any object concerning the authentication status. And because of that I gotta do something like this:

```
authSelector: (state) => isAuthenticated(state) ? { foo: 'bar' } : null,

```

Great project BTW, Thanks!