### PR TITLE
Added chainUserAuthWrapper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,42 @@ means that logged out admins will be redirected to `/login` before checking if t
 Otherwise admins would be sent to `/app` if they weren't logged in and then redirected to `/login`, only to find themselves at `/app`
 after entering their credentials.
 
+## Chainging of AuthWrappers
+
+An alternative way to declare :
+```
+<Route path="foo" component={UserIsAuthenticated(UserIsAdmin(Admin))}/>
+```
+is to chain the authwrappers together, this can be done using the `chainUserAuthWrapper` function.
+
+```
+import {UserAuthWrapper,chainUserAuthWrapper} from 'redux-auth-wrapper';
+
+// Take the regular authentication & redirect to login from before
+const UserIsAuthenticated = UserAuthWrapper({
+  authSelector: state => state.user,
+  redirectAction: routerActions.replace,
+  wrapperDisplayName: 'UserIsAuthenticated'
+})
+// Admin Authorization, redirects non-admins to /app and don't send a redirect param
+const UserIsAdmin = UserAuthWrapper({
+  authSelector: state => state.user,
+  redirectAction: routerActions.replace,
+  failureRedirectPath: '/app',
+  wrapperDisplayName: 'UserIsAdmin',
+  predicate: user => user.isAdmin,
+  allowRedirectBack: false
+})
+
+const AuthenticatedAndAdmin = chainUserAuthWrapper(UserIsAuthenticated,UserIsAdmin);
+```
+
+No you can declare:
+```
+<Route path="foo" component={AuthenticatedAndAdmin(Admin)}/>
+```
+
+
 ## Hiding and Alternate Components
 
 #### Hiding Components

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "src"
   ],
   "scripts": {
-    "build": "mkdir -p lib && babel ./src --out-dir ./lib",
+    "build": "mkdirp lib && babel ./src --out-dir ./lib",
     "lint": "eslint src test",
-    "prepublish": "rm -rf lib && npm run build",
+    "prepublish": "rimraf lib && npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive --require test/init.js test/**/*-test.js",
     "test:cov": "babel-node --max-old-space-size=4076 $(npm bin)/babel-istanbul cover $(npm bin)/_mocha -- --require test/init.js test/**/*-test.js",
     "test:watch": "mocha --compilers js:babel-core/register --recursive --require test/init.js -w test/**/*-test.js"
@@ -45,6 +45,7 @@
     "expect": "1.20.2",
     "jsdom": "9.8.3",
     "lodash": "4.16.6",
+    "mkdirp": "^0.5.1",
     "mocha": "3.1.2",
     "react": "15.3.2",
     "react-addons-test-utils": "15.3.2",
@@ -53,6 +54,7 @@
     "react-router": "3.0.0",
     "react-router-redux": "4.0.7",
     "redux": "3.6.0",
+    "rimraf": "^2.6.1",
     "sinon": "1.17.6",
     "webpack": "1.13.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -168,3 +168,9 @@ export const UserAuthWrapper = (args) => {
 
   return wrapComponent
 }
+
+export const chainUserAuthWrapper = (first,second)=>{
+    return function(DecoratedComponent){
+        return first(second(DecoratedComponent));
+    }
+}


### PR DESCRIPTION
Consider the case: 
```
// Take the regular authentication & redirect to login from before
const UserIsAuthenticated = UserAuthWrapper({
  authSelector: state => state.user,
  redirectAction: routerActions.replace,
  wrapperDisplayName: 'UserIsAuthenticated'
})
// Admin Authorization, redirects non-admins to /app and don't send a redirect param
const UserIsAdmin = UserAuthWrapper({
  authSelector: state => state.user,
  redirectAction: routerActions.replace,
  failureRedirectPath: '/app',
  wrapperDisplayName: 'UserIsAdmin',
  predicate: user => user.isAdmin,
  allowRedirectBack: false
})
```
Your intention is that the user is Authenticated before UserIsAdmin is called, a small mistake like this is easily made:
```
<Route path="foo" component={UserIsAdmin(Admin)}/>
```
This can be solved with chainUserAuthWrapper: 
```
// Take the regular authentication & redirect to login from before
const UserIsAuthenticated = UserAuthWrapper({
  authSelector: state => state.user,
  redirectAction: routerActions.replace,
  wrapperDisplayName: 'UserIsAuthenticated'
})
// Admin Authorization, redirects non-admins to /app and don't send a redirect param
const UserIsAdmin = chainUserAuthWrapper(UserIsAuthenticated ,UserAuthWrapper({
  authSelector: state => state.user,
  redirectAction: routerActions.replace,
  failureRedirectPath: '/app',
  wrapperDisplayName: 'UserIsAdmin',
  predicate: user => user.isAdmin,
  allowRedirectBack: false
}))
```
Now UserIsAdmin  will always use UserIsAuthenticated and: 
```
<Route path="foo" component={UserIsAdmin(Admin)}/>
```
works as expected. 
