### PR TITLE
React-boilerplate build:dll error fix

### DIFF
--- a/docs/Migrating.md
+++ b/docs/Migrating.md
@@ -105,9 +105,9 @@ const AdminOrElse = (Component, FailureComponent) => UserAuthWrapper({
 
 v2.x
 ```js
-import authWrapper from 'redux-auth-wrapper/authWrapper'
+import connectedAuthWrapper from 'redux-auth-wrapper/connectedAuthWrapper'
 
-const AdminOrElse = (Component, FailureComponent) => UserAuthWrapper({
+const AdminOrElse = (Component, FailureComponent) => connectedAuthWrapper({
   authenticatedSelector: state => state.user !== null && state.user.isAdmin,
   wrapperDisplayName: 'AdminOrElse',
   FailureComponent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "redux-auth-wrapper",
   "version": "2.0.0",
+  "main": "index.js",
   "description": "A utility library for handling authentication and authorization for redux and react-router",
   "scripts": {
     "build": "mkdirp lib && babel ./src --out-dir ./lib",


### PR DESCRIPTION
Added a blank `index.js` file in `/src` and referenced it from `"main": "index.js"` in `package.json` to stop [react-boilerplate](https://github.com/react-boilerplate/react-boilerplate) development build/dll error. Updated migration docs typo referencing `authWrapper` and `UserAuthWrapper` as per issue #183 [comment](https://github.com/mjrussell/redux-auth-wrapper/issues/183#issuecomment-314978880).