### PR TITLE
Typo in ReactRouter4.md

### DIFF
--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -77,11 +77,11 @@ When `authenticatingSelector` returns true, no redirection will be performed and
 const userIsAuthenticated = connectedRouterRedirect({
   redirectPath: '/login',
   authenticatedSelector: state => state.user.data !== null,
-  wrapperDisplayName: 'UserIsAuthenticated'
+  wrapperDisplayName: 'UserIsAuthenticated',
   // Returns true if the user auth state is loading
   authenticatingSelector: state => state.user.isLoading,
   // Render this component when the authenticatingSelector returns true
-  AuthenticatingComponent: LoadingSpinner,
+  AuthenticatingComponent: LoadingSpinner
 })
 ```
 

--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -76,7 +76,7 @@ When `authenticatingSelector` returns true, no redirection will be performed and
 ```js
 const userIsAuthenticated = connectedRouterRedirect({
   redirectPath: '/login',
-  authenticatedSelector: state => state.user.data. !== null,
+  authenticatedSelector: state => state.user.data !== null,
   wrapperDisplayName: 'UserIsAuthenticated'
   // Returns true if the user auth state is loading
   authenticatingSelector: state => state.user.isLoading,

--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -94,7 +94,7 @@ If you want to dispatch a redux action to perform navigation instead of interact
 To do this, swap out the import of `connectedRouterRedirect` for `connectedReduxRedirect` and pass the `redirectAction` parameter to the config object:
 
 ```js
-import { connectedReduxRedirect } from 'redux-auth-wrapper/history3/redirect'
+import { connectedReduxRedirect } from 'redux-auth-wrapper/history4/redirect'
 import { routerActions } from 'react-router-redux'
 
 const userIsAuthenticated = connectedReduxRedirect({


### PR DESCRIPTION
* Forgotten dot in `userIsAuthenticated` object
* Broken commas in `userIsAuthenticated ` object
* Import of `connectedReduxRedirect` from `history3`