### PR TITLE
Add build for es6 modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,25 @@
 {
-  "presets": ["es2015", "react", "stage-0"],
-  "plugins": [
-    ["transform-decorators-legacy"],
-  ]
+
+  "env": {
+  "development": {
+    "presets": [
+      ["es2015"],
+      "react",
+      "stage-0"
+    ],
+    "plugins": [
+      ["transform-decorators-legacy"],
+    ]
+  },
+  "es": {
+    "presets": [
+      ["es2015", { "modules": false }],
+      "react",
+      "stage-0"
+    ],
+    "plugins": [
+      ["transform-decorators-legacy"],
+    ]
+  }
+}
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "description": "A utility library for handling authentication and authorization for redux and react-router",
   "scripts": {
-    "build": "mkdirp lib && babel ./src --out-dir ./lib",
+    "build": "mkdirp lib && npm run build:cjs && npm run build:es",
+    "build:cjs": "babel ./src --out-dir ./lib",
+    "build:es": "BABEL_ENV=es babel ./src --out-dir ./lib/es",
     "build:clean": "rimraf ./lib",
     "build:copyFiles": "cp -rf package.json LICENSE.txt README.md lib/.",
     "dist": "cd lib && npm publish",


### PR DESCRIPTION
Adds second build of library without transforming es modules.

It enables Webpack 3 to do tree shaking and scope hoisting when used with 'es' path:
import { connectedReduxRedirect } from 'redux-auth-wrapper/**es**/history3/redirect'

Closes https://github.com/mjrussell/redux-auth-wrapper/issues/194