### PR TITLE
Update propTypes for latest react version at least v.15.15

### DIFF
--- a/examples/react-router-4/components/Login.js
+++ b/examples/react-router-4/components/Login.js
@@ -1,4 +1,7 @@
 import React, { Component, PropTypes } from 'react'
+// If you would use react latest version please see below:
+// React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.
+// import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import styles from './App.css'
 import { login } from '../actions/user'


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.
```
 - import React, { Component, PropTypes } from 'react'
 + import React, { Component} from 'react'
 + import PropTypes from 'prop-types';
```