### PR TITLE
fix typo doc redir uri (causes URIError: URI malformed)

### DIFF
--- a/docs/Getting-Started/ReactRouter3.md
+++ b/docs/Getting-Started/ReactRouter3.md
@@ -38,7 +38,7 @@ When the user navigates to `/profile`, one of the following occurs:
 
 1. If The `state.user` is null:
 
-    The user is redirected to `/login?redirect=%2profile`
+    The user is redirected to `/login?redirect=%2Fprofile`
 
     *Notice the url contains the query parameter `redirect` for sending the user back to after you log them into your app*
 2. Otherwise:

--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -35,7 +35,7 @@ When the user navigates to `/profile`, one of the following occurs:
 
 1. If The `state.user` is null:
 
-    The user is redirected to `/login?redirect=%2profile`
+    The user is redirected to `/login?redirect=%2Fprofile`
 
     *Notice the url contains the query parameter `redirect` for sending the user back to after you log them into your app*
 2. Otherwise:


### PR DESCRIPTION
Firts of all thanks for the excellent library.

This is fix of little typo in doc causes the exception if used.