### PR TITLE
Fix doc bind location

### DIFF
--- a/docs/Getting-Started/ReactRouter3.md
+++ b/docs/Getting-Started/ReactRouter3.md
@@ -38,7 +38,7 @@ When the user navigates to `/profile`, one of the following occurs:
 
 1. If The `state.user` is null:
 
-    The user is redirected to `/login?redirect=%2profile`
+    The user is redirected to `/login?redirect=%2Fprofile`
 
     *Notice the url contains the query parameter `redirect` for sending the user back to after you log them into your app*
 2. Otherwise:

--- a/docs/Getting-Started/ReactRouter3.md
+++ b/docs/Getting-Started/ReactRouter3.md
@@ -71,6 +71,8 @@ const userIsNotAuthenticated = connectedRouterRedirect({
 <Route path="login" component={userIsNotAuthenticated(Login)}/>
 ```
 
+The `locationHelper` requre `location` object in props. Therefore if component is not directly route component then `withRouter` must be applied before, for example like this `withRouter(userIsNotAuthenticated(Login))`.
+
 ## Displaying an AuthenticatingComponent Component
 
 Its often useful to display some sort of loading component or animation when you are checking if the user's credentials are valid or if the user is already logged in. We can add a loading component to both our Login and Profile page easily:

--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -35,7 +35,7 @@ When the user navigates to `/profile`, one of the following occurs:
 
 1. If The `state.user` is null:
 
-    The user is redirected to `/login?redirect=%2profile`
+    The user is redirected to `/login?redirect=%2Fprofile`
 
     *Notice the url contains the query parameter `redirect` for sending the user back to after you log them into your app*
 2. Otherwise:

--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -69,6 +69,8 @@ const userIsNotAuthenticated = connectedRouterRedirect({
 <Route path="login" component={userIsNotAuthenticated(Login)}/>
 ```
 
+The `locationHelper` requre `location` object in props. Therefore if component is not directly route component then `withRouter` must be applied before, for example like this `withRouter(userIsNotAuthenticated(Login))`.
+
 ## Displaying an AuthenticatingComponent Component
 
 Its often useful to display some sort of loading component or animation when you are checking if the user's credentials are valid or if the user is already logged in. We can add a loading component to both our Login and Profile page easily:


### PR DESCRIPTION
The wrappers may be used in some another ways not only as route component, for example as subcomponents or in code splitting. Components have not access to location object by default, so `locationHelper` will select `undefined` value. This patch mention that in doc to avoid crashes caused by access to `undefined` instead of `location` object.