### PR TITLE
Fix doc location required

### DIFF
--- a/docs/Getting-Started/ReactRouter3.md
+++ b/docs/Getting-Started/ReactRouter3.md
@@ -71,6 +71,12 @@ const userIsNotAuthenticated = connectedRouterRedirect({
 <Route path="login" component={userIsNotAuthenticated(Login)}/>
 ```
 
+The `locationHelper` requires the `location` object in props. If the component is not rendered as part of a route component then you must use the `withRouter` HOC from `react-router`:
+
+```js
+withRouter(userIsNotAuthenticated(Login))
+```  
+
 ## Displaying an AuthenticatingComponent Component
 
 Its often useful to display some sort of loading component or animation when you are checking if the user's credentials are valid or if the user is already logged in. We can add a loading component to both our Login and Profile page easily:

--- a/docs/Getting-Started/ReactRouter4.md
+++ b/docs/Getting-Started/ReactRouter4.md
@@ -69,6 +69,12 @@ const userIsNotAuthenticated = connectedRouterRedirect({
 <Route path="login" component={userIsNotAuthenticated(Login)}/>
 ```
 
+The `locationHelper` requires the `location` object in props. If the component is not rendered as part of a route component then you must use the `withRouter` HOC from `react-router`:
+
+```js
+withRouter(userIsNotAuthenticated(Login))
+```  
+
 ## Displaying an AuthenticatingComponent Component
 
 Its often useful to display some sort of loading component or animation when you are checking if the user's credentials are valid or if the user is already logged in. We can add a loading component to both our Login and Profile page easily:


### PR DESCRIPTION
The wrappers may be used in some another ways not only as route component, for example as subcomponents or in code splitting. Components have not access to location object by default, so `locationHelper` will select `undefined` value. This patch mention that in doc to avoid crashes caused by access to `undefined` instead of `location` object.