### PR TITLE
Add unsafe to component mount

### DIFF
--- a/src/redirect.js
+++ b/src/redirect.js
@@ -8,7 +8,7 @@ export default class Redirect extends Component {
     redirect: PropTypes.func.isRequired
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.redirect(this.props, this.props.redirectPath)
   }
 


### PR DESCRIPTION
Noticed a deprecation warning ahead of React 17. I've been working on trying to narrow down my project's warnings. 

<img width="810" alt="Screen Shot 2019-10-17 at 4 58 21 PM" src="https://user-images.githubusercontent.com/5950956/67051498-da85b300-f100-11e9-8052-3d8ad447f033.png">

https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html