### PR TITLE
V1.x bump and loosen prop-types dependency to get rid of audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   "dependencies": {
     "hoist-non-react-statics": "1.2.0",
     "lodash.isempty": "4.4.0",
-    "prop-types": "15.5.8"
+    "prop-types": "^15.5.7"
   }
 }


### PR DESCRIPTION
prop-types@15.5.8 depends on a version of fbjs which i affected by https://www.npmjs.com/advisories/1556

bumped and loosen prop-types dependency

is v1.x still being maintained?

would be awesome if we could have a minor release on v.1 with this  PR