### PR TITLE
Document correction - update ReactRouter3.md

### DIFF
--- a/docs/Getting-Started/ReactRouter3.md
+++ b/docs/Getting-Started/ReactRouter3.md
@@ -60,7 +60,7 @@ const userIsNotAuthenticated = connectedRouterRedirect({
   // This prevents us from adding the query parameter when we send the user away from the login page
   allowRedirectBack: false,
   // Determine if the user is authenticated or not
-  authenticatedSelector: state => state.user.data !== null,
+  authenticatedSelector: state => state.user === null,
   // A nice display name for this check
   wrapperDisplayName: 'UserIsNotAuthenticated'
 })
@@ -86,7 +86,7 @@ When `authenticatingSelector` returns true, no redirection will be performed and
 ```js
 const userIsAuthenticated = connectedRouterRedirect({
   redirectPath: '/login',
-  authenticatedSelector: state => state.user.data. !== null,
+  authenticatedSelector: state => state.user !== null,
   wrapperDisplayName: 'UserIsAuthenticated'
   // Returns true if the user auth state is loading
   authenticatingSelector: state => state.user.isLoading,


### PR DESCRIPTION
First, thanks for building such a useful HOC! I know react-router-3 is quite aged and may rarely be used in the community today, but I believe there must be still some would like to adopt this library to save their life like me. :raised_hands: 

The changes are the same as the commit message:

1. Correct the code logic in the example of `userIsNotAuthenticated`.
2. Align minor inconsistencies in code examples.

FYI: The doc on Gitbook needs updates too.

------------------------------------------------------
Also here is a proposal, would like to hear how the author and maintainers of this repo think:
I think the name of property `authenticatedSelector` in `connectedRouterRedirect` could be changed to a more neutral one. At the beginning, I misunderstood that the usage of `connectedRouterRedirect` is only for redirecting not valid/logged-in users to the page for authentication, cuz `authenticatedSelector` makes me think that it implies a "valid" status. I guess the doc's small mistake corrected with this PR was likely caused by a moment of confusion on this too.

@mjrussell 